### PR TITLE
Docs: fix markdown lint issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
 # SQLite Metadata Proposal
 
-This repository hosts a living proposal for building a cloud-agnostic metadata platform on top of SQLite. The goal is to capture design decisions, research notes, and implementation plans in a highly collaborative format that works for both humans and automation agents.
+This repository hosts a living proposal for building a cloud-agnostic metadata
+platform on top of SQLite. The goal is to capture design decisions, research
+notes, and implementation plans in a highly collaborative format that works for
+both humans and automation agents.
 
 ## Quick Links
+
 - [Proposal](./sqlite-metadata-system.md)
 - [Working Agreement](./docs/process.md)
 - [Research Notes](./docs/notes)
 - [Issues](https://github.com/ganesh47/sqlite-metadata-proposal/issues)
-- Project Board: _Created automatically once the classic project API becomes available_
+- Project Board: _Created automatically once the classic project API becomes
+  available_
 
 ## Getting Started
+
 ```bash
 git clone https://github.com/ganesh47/sqlite-metadata-proposal.git
 cd sqlite-metadata-proposal
@@ -19,28 +25,36 @@ gh repo sync
 1. Review open issues and the project board to understand current priorities.
 2. Open or select an issue (Planning / Research template) and self-assign.
 3. Create a feature branch (`git switch -c docs/section-update-<issue#>`).
-4. Make changes, update the proposal or notes, and open a pull request using the template.
+4. Make changes, update the proposal or notes, and open a pull request using
+   the template.
 5. Ensure CI checks (markdown lint, link check) pass before requesting review.
 
 ## Automation
-| Workflow | Trigger | Description |
-|----------|---------|-------------|
-| `markdown-lint` | PRs & pushes touching `.md` | Enforces documentation style consistency. |
-| `link-check` | PRs & weekly schedule | Validates outbound links to keep references fresh. |
-| `auto-assign` | PRs & issues | Auto-assigns work to @ganesh47 when unassigned. |
 
-The project board uses the `Stage` single-select field with steps **Backlog → Selected → In Progress → Review → Done**.
+- `markdown-lint`: Runs on PRs and pushes touching `.md` to enforce style
+  consistency.
+- `link-check`: Runs on PRs and a weekly schedule to keep references fresh.
+- `auto-assign`: Runs on PRs and issues to auto-assign work to @ganesh47.
+
+The project board uses the `Stage` single-select field with steps **Backlog →
+Selected → In Progress → Review → Done**.
 
 ## Collaboration Rules
+
 - Branch per task; keep history tidy with squash merges.
 - Reference issues in commits/PRs (`Closes #<id>`).
 - Capture context in `docs/notes/YYYY-MM-DD.md` for research spikes.
 - Use labels + milestones to track progress toward proposal maturity.
 
 ## Roadmap Milestones
-1. **M1 – Foundations**: Complete scaffolding, workflows, and baseline proposal structure.
+
+1. **M1 – Foundations**: Complete scaffolding, workflows, and baseline proposal
+   structure.
 2. **M2 – Architecture Draft**: Produce the first end-to-end design narrative.
-3. **M3 – Implementation Plan**: Translate the proposal into actionable project work.
+3. **M3 – Implementation Plan**: Translate the proposal into actionable project
+   work.
 
 ## Support
-Open a discussion if you have questions or suggestions: _Discussions will be enabled soon to support broader async collaboration._
+
+Open a discussion if you have questions or suggestions: _Discussions will be
+enabled soon to support broader async collaboration._

--- a/sqlite-metadata-system.md
+++ b/sqlite-metadata-system.md
@@ -1,29 +1,58 @@
 # Proposal: Cloud-Agnostic Metadata Graph Platform on SQLite
 
 ## 1. Executive Summary
-- **Objective**: Reimagine the current Cloudflare-centric metadata system as a portable, open-source platform that runs on any infrastructure (VM, container, desktop) with SQLite as the primary storage engine.
-- **Motivation**: Preserve the strengths of the existing implementation—graph-first modeling, audit trails, RAG readiness—while eliminating the dependency on Cloudflare Workers/KV/R2, and unlocking offline, edge, or self-hosted deployments.
-- **Outcome**: Deliver a drop-in replacement API, web console, and tooling stack that teams can self-host, embed into products, or extend with custom plugins.
+
+- **Objective**: Reimagine the current Cloudflare-centric metadata system as a
+  portable, open-source platform that runs on any infrastructure (VM, container,
+  desktop) with SQLite as the primary storage engine.
+- **Motivation**: Preserve the strengths of the existing
+  implementation—graph-first modeling, audit trails, and RAG readiness—while
+  eliminating the dependency on
+  Cloudflare Workers/KV/R2, and unlocking offline, edge, or self-hosted
+  deployments.
+- **Outcome**: Deliver a drop-in replacement API, web console, and tooling stack
+  that teams can self-host, embed into products, or extend with custom plugins.
 
 ## 2. Key Learnings from the Current System
-| Observation | Impact on New Design |
-|-------------|----------------------|
-| Worker-based API is cost-efficient but tightly coupled to Cloudflare bindings (KV, D1, R2, Qdrant). | Storage, caching, and vector search must be reimagined with open-source equivalents and clean abstractions. |
-| Request-level telemetry and auth guard patterns proved effective. | Preserve middleware structure with adapters for popular frameworks (Express, Fastify, gRPC, etc.). |
-| Embedding workflow (Together AI → Qdrant) is powerful but optional. | Provide pluggable embedding + vector search layer; default to local-sqlite FTS, allow remote vector stores via config. |
-| CI pipeline integrates performance load tests and schema enforcement. | Reuse automated testing approach; integrate SQLite migrations, seed data, smoke tests. |
-| Front-end expects API shapes (`{ data, pagination }`) and OIDC-backed session cookies. | Keep API contracts stable; add config to run with local identity providers or API keys. |
+
+- **Worker-based API**: Cost-efficient but tightly coupled to Cloudflare
+  bindings (KV, D1, R2, Qdrant).
+  - **Impact**: Reimagine storage, caching, and vector search with open-source
+    equivalents and clean abstractions.
+- **Telemetry and auth guards**: Request-level patterns proved effective.
+  - **Impact**: Preserve the middleware structure with adapters for popular
+    frameworks (Express, Fastify, gRPC, etc.).
+- **Embedding workflow**: The Together AI → Qdrant pipeline is powerful but
+  optional.
+  - **Impact**: Provide a pluggable embedding and vector search layer; default
+    to local SQLite FTS while allowing remote stores via configuration.
+- **CI pipeline**: Integrates performance load tests and schema enforcement.
+  - **Impact**: Reuse the automated testing approach; integrate SQLite
+    migrations, seed data, and smoke tests.
+- **Front-end expectations**: Requires `{ data, pagination }` responses and
+  OIDC-backed session cookies.
+  - **Impact**: Keep API contracts stable and add configuration for local
+    identity providers or API keys.
 
 ## 3. Vision & Design Principles
-1. **Cloud-Agnostic** – Run on laptops, private data centers, or cloud VMs using standard runtimes (Node.js, Bun, Deno, Go, Rust).
-2. **SQLite-Centric** – Use SQLite (with JSON1, FTS5, and R*Tree extensions where available) for nodes, edges, embeddings, and audit logs.
-3. **Pluggable & Modular** – Clear boundaries between storage, auth, API, and analytics. Swap components without rewriting core logic.
-4. **Graph-native Semantics** – Preserve directed edges, properties, and traversal semantics honed in the Cloudflare version.
-5. **Developer-Friendly** – Single binary or Docker image with sensible defaults; optional dev server featuring hot reload.
-6. **RAG-Ready** – Offer local embedding & vector search options (e.g., `sqlite-vss`, `pgvector` shim) while supporting remote providers through adapters.
+
+1. **Cloud-agnostic** – Run on laptops, private data centers, or cloud VMs using
+   standard runtimes (Node.js, Bun, Deno, Go, Rust).
+2. **SQLite-centric** – Use SQLite (with JSON1, FTS5, and R*Tree extensions
+   where available) for nodes, edges, embeddings, and audit logs.
+3. **Pluggable & modular** – Maintain clear boundaries between storage, auth,
+   API, and analytics so teams can swap components without rewriting core logic.
+4. **Graph-native semantics** – Preserve directed edges, properties, and
+   traversal semantics honed in the Cloudflare version.
+5. **Developer-friendly** – Ship a single binary or Docker image with sensible
+   defaults; offer an optional dev server featuring hot reload.
+6. **RAG-ready** – Offer local embedding and vector search options (e.g.,
+   `sqlite-vss`, `pgvector` shim) while supporting remote providers through
+   adapters.
 
 ## 4. High-Level Architecture
-```
+
+```text
 ┌──────────────────┐
 │   Client Apps     │  (Next.js console, CLI, integrations)
 └────────┬─────────┘
@@ -59,15 +88,21 @@
 ```
 
 ### Core Modules
+
 1. **API Server**
-   - Use Fastify (Node.js) or Axum (Rust) for performance and plugin ecosystem.
-   - Bundle OpenAPI spec + automatic docs.
-   - Implement the same routes as current worker (`/:orgId/nodes`, `/:orgId/edges`, `/orgs`, `/:orgId/metadata/export`, etc.).
-   - Middleware chain: logging → CORS → rate limiting → auth → route handler.
+   - Use Fastify (Node.js) or Axum (Rust) for performance and a rich plugin
+     ecosystem.
+   - Bundle the OpenAPI spec with automatic documentation.
+   - Implement the same routes as the current worker (`/:orgId/nodes`,
+     `/:orgId/edges`, `/orgs`, `/:orgId/metadata/export`, etc.).
+   - Maintain a middleware chain: logging → CORS → rate limiting → auth →
+     route handler.
 
 2. **Storage Layer**
-   - SQLite database file with migrations managed by Prisma, Kysely, or Drizzle (if Node) or SQLx (Rust).
+   - SQLite database file with migrations managed by Prisma, Kysely, or Drizzle
+     (if Node) or SQLx (Rust).
    - Schema mirroring D1 tables:
+
      ```sql
      CREATE TABLE graph_nodes (
        id TEXT NOT NULL,
@@ -84,34 +119,43 @@
      );
      CREATE INDEX idx_nodes_org_type ON graph_nodes(org_id, type);
      ```
+
    - Edges table with foreign-key enforcement.
    - Triggers to keep `updated_at` current.
 
 3. **Traversal & Query Engine**
    - Re-implement traversals using recursive CTEs in SQLite.
    - Provide streaming iterators for large graphs.
-   - Offer pluggable in-memory cache (LRU) for hot nodes (optional, default off).
+   - Offer a pluggable in-memory cache (LRU) for hot nodes (optional, default
+     off).
 
 4. **Embedding & Search**
    - Default: use SQLite JSON/FTS for text search.
-   - Optional: integrate `sqlite-vss` extension or external vector DB (Qdrant, Weaviate) via adapter.
-   - Provide background worker process for embedding generation (OpenAI, local transformers).
+   - Optional: integrate the `sqlite-vss` extension or an external vector DB
+     (Qdrant, Weaviate) via an adapter.
+   - Provide a background worker process for embedding generation (OpenAI or
+     local transformers).
 
 5. **Import/Export + Backup**
    - JSON-based import/export CLI using SQLite transactions.
-   - Snapshot command to dump `.sqlite` file or `.sql`.
-   - Supply migration from Cloudflare D1 (SQL export) to SQLite, using ETL script.
+   - Snapshot command to dump the `.sqlite` file or emit `.sql`.
+   - Supply migration from Cloudflare D1 (SQL export) to SQLite using an ETL
+     script.
 
 6. **Observability**
    - Structured logging (pino or bunyan) with log-level control.
    - Health checks (`/health/live`, `/health/ready`).
-  - Optional Prometheus metrics endpoint.
+   - Optional Prometheus metrics endpoint.
 
 ## 5. Front-End & Tooling
+
 1. **Web Console**
-   - Reuse existing Next.js UI, replacing Cloudflare fetch URLs with configurable base URL.
-   - Authentication via same OIDC provider or local API key (fallback, for demos).
-   - Extend UI: graph visualization (D3/React Flow), node/edge editors, traversal explorer.
+   - Reuse the existing Next.js UI, replacing Cloudflare fetch URLs with a
+     configurable base URL.
+   - Authenticate via the same OIDC provider or a local API key (fallback for
+     demos).
+   - Extend the UI with graph visualization (D3 or React Flow), node/edge
+     editors, and a traversal explorer.
 
 2. **CLI Tool**
    - Provide `metadata-cli` for:
@@ -125,62 +169,94 @@
    - Python client for ingestion scripts.
 
 ## 6. Deployment & Operations
-| Target | Recommendation |
-|--------|----------------|
-| Local Development | `docker compose up` with API server + SQLite volume; autoreload options. |
-| Self-hosted VM | Systemd service or Docker container; mount persistent volume for `.sqlite`. |
-| Cloud | Works on any provider (AWS EC2, GCP Compute Engine, Fly.io). Optionally layer on managed SQLite services (LiteFS, Turso, PlanetScale serverless driver). |
-| Scaling | Horizontal read replicas via Litestream/LiteFS; for larger workloads, allow migration path to Postgres while keeping same API. |
+
+- **Local development**: `docker compose up` with the API server and SQLite
+  volume; enable autoreload options for quick feedback.
+- **Self-hosted VM**: Run as a Systemd service or Docker container; mount a
+  persistent volume for the `.sqlite` database file.
+- **Cloud**: Works on any provider (AWS EC2, GCP Compute Engine, Fly.io);
+  optionally layer on managed SQLite services (LiteFS, Turso, PlanetScale
+  serverless driver).
+- **Scaling**: Use horizontal read replicas with Litestream or LiteFS; provide a
+  migration path to Postgres for heavier workloads while keeping the same API.
 
 ### Reliability
+
 - Automatic WAL checkpointing and backup via Litestream or LiteFS.
 - Transactional migrations with version table.
-- Configurable rate limits and request quotas per org (Redis or in-process token bucket).
+- Configurable rate limits and request quotas per org (Redis or in-process
+  token bucket).
 
 ## 7. Security & Auth Strategy
-- **Auth Modes** (pluggable):
+
+- **Auth modes** (pluggable):
   1. OIDC/JWT (Keycloak, Auth0, Azure AD).
   2. API keys per org (for service-to-service usage).
   3. mTLS (optional for enterprise).
-- RBAC scope model identical to current system (`<orgId>:read`, `<orgId>:write`, wildcard).
-- Audit logs stored in `audit_events` table (action, actor, timestamp, payload).
+- RBAC scope model identical to the current system (`<orgId>:read`,
+  `<orgId>:write`, wildcard).
+- Audit logs stored in the `audit_events` table (action, actor, timestamp,
+  payload).
 - Sensitive logging stripped (no token dumps).
 
 ## 8. Migration Path from Cloudflare Version
-1. **Export** data from D1 using Wrangler or `cf-graphdb-api` export endpoint per org.
-2. **Transform** exports (if necessary) to align with new schema using ETL script.
+
+1. **Export** data from D1 using Wrangler or the `cf-graphdb-api` export
+   endpoint per org.
+2. **Transform** exports (if necessary) to align with the new schema using an
+   ETL script.
 3. **Import** into SQLite using `metadata-cli import`.
-4. **Redirect** front-end `.env` to new API URL.
-5. **Replace** Cloudflare-specific env vars with new config file (`config/default.yaml`).
+4. **Redirect** the front-end `.env` to the new API URL.
+5. **Replace** Cloudflare-specific env vars with the new config file
+   (`config/default.yaml`).
 
 ## 9. Delivery Plan & Milestones
-| Phase | Duration | Deliverables |
-|-------|----------|--------------|
-| 0 – Discovery | 1 week | Detailed requirements, tech stack selection (Node/Fastify + Drizzle recommended). |
-| 1 – Foundations | 2 weeks | SQLite schema + migration tooling, API skeleton with auth middleware, CI pipeline. |
-| 2 – Core Features | 3 weeks | Nodes/edges CRUD, traversal/query, import/export, CLI bootstrap. |
-| 3 – Vector + Search | 2 weeks | FTS integration, optional vector adapter, background embedding worker. |
-| 4 – Front-end Integration | 2 weeks | Update Next.js console, OIDC/Auth wiring, UX improvements. |
-| 5 – Hardening | 2 weeks | Performance tests (k6/Locust), security review, docs, packaging (Docker, binary). |
-| 6 – Migration & Launch | 1 week | D1 → SQLite migration scripts, GA announcement. |
+
+- **Phase 0 – Discovery (1 week)**: Finalize detailed requirements and select
+  the tech stack (Node/Fastify with Drizzle recommended).
+- **Phase 1 – Foundations (2 weeks)**: Build the SQLite schema, migration
+  tooling, API skeleton with auth middleware, and CI pipeline.
+- **Phase 2 – Core Features (3 weeks)**: Implement node and edge CRUD,
+  traversal/query flows, import/export features, and the CLI bootstrap.
+- **Phase 3 – Vector + Search (2 weeks)**: Integrate FTS, add an optional vector
+  adapter, and ship the background embedding worker.
+- **Phase 4 – Front-end Integration (2 weeks)**: Update the Next.js console,
+  wire up OIDC/Auth, and deliver UX improvements.
+- **Phase 5 – Hardening (2 weeks)**: Run performance tests (k6 or Locust),
+  complete the security review, polish docs, and prepare packaging (Docker,
+  binary).
+- **Phase 6 – Migration & Launch (1 week)**: Provide D1 → SQLite migration
+  scripts and publish the GA announcement.
 
 ## 10. Risks & Mitigations
-- **SQLite at Scale**: Single-writer limitation; mitigate with WAL mode, job queue for heavy writes, plan migration path to Postgres when needed.
-- **Embedding Performance**: Running local embeddings may be resource-intensive; allow asynchronous pipelines and remote providers.
-- **Auth Complexity**: Provide templates for OIDC and API key flows; include integration tests.
-- **Data Consistency**: Without KV, rely on SQLite and optional in-memory caches; ensure delete/update handlers invalidate caches correctly.
+
+- **SQLite at scale**: Single-writer limitation; mitigate with WAL mode, a job
+  queue for heavy writes, and a planned migration path to Postgres when needed.
+- **Embedding performance**: Running local embeddings can be resource-intensive;
+  allow asynchronous pipelines and support remote providers.
+- **Auth complexity**: Provide templates for OIDC and API key flows; include
+  integration tests.
+- **Data consistency**: Without KV, rely on SQLite and optional in-memory
+  caches; ensure delete/update handlers invalidate caches correctly.
 
 ## 11. Success Metrics
-- Time-to-first-setup < 10 minutes (from `git clone` to running API with sample data).
-- Import/export parity with Cloudflare version.
-- Sustained throughput: 100 RPS read, 20 RPS write on mid-tier VM without errors.
-- Traversal latency (depth=3, graph=5k nodes) < 300 ms median.
-- 80% test coverage across API, storage, and CLI.
+
+- Time-to-first-setup under 10 minutes (from `git clone` to a running API with
+  sample data).
+- Import/export parity with the existing Cloudflare version.
+- Sustained throughput of 100 RPS read and 20 RPS write on a mid-tier VM
+  without errors.
+- Traversal latency (depth = 3, graph = 5k nodes) under 300 ms median.
+- 80% test coverage across the API, storage, and CLI.
 
 ## 12. Next Steps
-1. Approve scope and target stack (Fastify + TypeScript + Drizzle recommended).
-2. Set up repository scaffold (`packages/api`, `packages/cli`, `apps/web`).
-3. Author migration tool for current datasets (YouTube8M ingestion to SQLite).
+
+1. Approve the scope and target stack (Fastify + TypeScript + Drizzle
+   recommended).
+2. Set up the repository scaffold (`packages/api`, `packages/cli`, `apps/web`).
+3. Author the migration tool for current datasets (YouTube8M ingestion to
+   SQLite).
 4. Begin Phase 1 implementation with iterative demos every sprint.
 
-_Prepared as a forward-looking plan leveraging lessons from the Cloudflare implementation while enabling a broader deployment footprint._.
+Prepared as a forward-looking plan that leverages lessons from the Cloudflare
+implementation while enabling a broader deployment footprint.


### PR DESCRIPTION
## Summary
- wrap long headings and tables to satisfy markdownlint
- restructure sections to add required blank lines and keep lint clean