### PR TITLE
Fix Vitest harness (issue #14)

### DIFF
--- a/packages/api/tests/setup.ts
+++ b/packages/api/tests/setup.ts
@@ -1,9 +1,24 @@
-import { beforeAll, afterAll } from "vitest";
+import { mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { beforeAll, afterAll, beforeEach } from "vitest";
+
+const ensureDbPath = () => {
+  const dbPath = process.env.SQLITE_PATH ?? ".vitest/metadata.sqlite";
+  const absolute = resolve(dbPath);
+  mkdirSync(dirname(absolute), { recursive: true });
+  process.env.SQLITE_PATH = absolute;
+};
 
 beforeAll(() => {
-  process.env.SQLITE_PATH = process.env.SQLITE_PATH ?? ".vitest/metadata.sqlite";
+  ensureDbPath();
+  process.env.API_PORT = process.env.API_PORT ?? "8080";
+});
+
+beforeEach(() => {
+  // Reset per-test timing budget markers if future hooks require them.
+  process.env.__TEST_STARTED_AT = Date.now().toString();
 });
 
 afterAll(() => {
-  // Placeholder for cleaning up resources once Fastify app is added.
+  delete process.env.__TEST_STARTED_AT;
 });

--- a/packages/api/vitest.config.ts
+++ b/packages/api/vitest.config.ts
@@ -3,14 +3,25 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
+    setupFiles: ["./tests/setup.ts"],
+    globals: true,
+    testTimeout: 10_000,
+    hookTimeout: 10_000,
+    maxThreads: 4,
+    minThreads: 1,
+    watchExclude: ["dist/**", "docker/**", "packages/cli/**", "packages/connectors/**"],
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],
       lines: 80,
       functions: 80,
-      branches: 70
-    },
-    setupFiles: ["./tests/setup.ts"],
-    globals: true
+      branches: 70,
+      watermarks: {
+        statements: [80, 90],
+        branches: [70, 85],
+        functions: [80, 90],
+        lines: [80, 90]
+      }
+    }
   }
 });


### PR DESCRIPTION
## Summary\n- tighten Vitest config with timeouts, coverage watermarks, and watch excludes aligned with the implementation plan\n- expand setup helper to ensure the temp SQLite path exists and capture per-test timing markers\n\n## Testing\n- [x] pnpm dlx vitest run --config packages/api/vitest.config.ts (fails due to no tests, but config validated)\n